### PR TITLE
web: handle api errors

### DIFF
--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -1,4 +1,4 @@
-module Api exposing (Error(..), Response(..))
+module Api exposing (Error(..), Response(..), getErrorMessage)
 
 import Http
 import Json.Decode
@@ -19,3 +19,13 @@ type Response value
     = Loading
     | Success value
     | Failure Error
+
+
+getErrorMessage : Error -> String
+getErrorMessage error =
+    case error of
+        HttpError err ->
+            err.message
+
+        JsonDecodeError err ->
+            err.message

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -1,4 +1,4 @@
-module Api exposing (Error(..), Response(..), getErrorMessage)
+module Api exposing (Error(..), Response(..), errorMessage)
 
 import Http
 import Json.Decode
@@ -21,8 +21,8 @@ type Response value
     | Failure Error
 
 
-getErrorMessage : Error -> String
-getErrorMessage error =
+errorMessage : Error -> String
+errorMessage error =
     case error of
         HttpError err ->
             err.message

--- a/web/src/Api.elm
+++ b/web/src/Api.elm
@@ -1,46 +1,21 @@
-module Api exposing (HttpRequestDetails, Response(..), errorToFriendlyMessage)
+module Api exposing (Error(..), Response(..))
 
 import Http
 import Json.Decode
 
 
+type Error
+    = HttpError
+        { message : String
+        , reason : Http.Error
+        }
+    | JsonDecodeError
+        { message : String
+        , reason : Json.Decode.Error
+        }
+
+
 type Response value
     = Loading
     | Success value
-    | Failure Http.Error
-
-
-type alias HttpRequestDetails msg =
-    { endpoint : String
-    , method : String
-    , body : Http.Body
-    , decoder : Json.Decode.Decoder msg
-    , onHttpError : Http.Error -> msg
-    }
-
-
-errorToFriendlyMessage : Http.Error -> String
-errorToFriendlyMessage httpError =
-    case httpError of
-        Http.BadUrl _ ->
-            "This page requested a bad URL"
-
-        Http.Timeout ->
-            "Request took too long to respond"
-
-        Http.NetworkError ->
-            "Could not connect to the API"
-
-        Http.BadStatus code ->
-            case code of
-                404 ->
-                    "Not found"
-
-                401 ->
-                    "Unauthorized"
-
-                _ ->
-                    "API returned an error code"
-
-        Http.BadBody _ ->
-            "Unexpected response from API"
+    | Failure Error

--- a/web/src/Api/Auth.elm
+++ b/web/src/Api/Auth.elm
@@ -1,5 +1,6 @@
 module Api.Auth exposing (refreshToken, signin, signup)
 
+import Api
 import Data.Credentials as Credentials exposing (Credentials)
 import Effect exposing (Effect)
 import Http
@@ -8,7 +9,7 @@ import Json.Encode as Encode
 
 
 signin :
-    { onResponse : Result Http.Error Credentials -> msg
+    { onResponse : Result Api.Error Credentials -> msg
     , email : String
     , password : String
     }
@@ -32,7 +33,7 @@ signin options =
 
 
 signup :
-    { onResponse : Result Http.Error () -> msg
+    { onResponse : Result Api.Error () -> msg
     , email : String
     , password : String
     }
@@ -56,7 +57,7 @@ signup options =
 
 
 refreshToken :
-    { onResponse : Result Http.Error Credentials -> msg
+    { onResponse : Result Api.Error Credentials -> msg
     , refreshToken : String
     }
     -> Effect msg

--- a/web/src/Api/Me.elm
+++ b/web/src/Api/Me.elm
@@ -1,11 +1,12 @@
 module Api.Me exposing (get)
 
+import Api
 import Data.Me as Me exposing (Me)
 import Effect exposing (Effect)
 import Http
 
 
-get : { onResponse : Result Http.Error Me -> msg } -> Effect msg
+get : { onResponse : Result Api.Error Me -> msg } -> Effect msg
 get options =
     Effect.sendApiRequest
         { endpoint = "/api/v1/me"

--- a/web/src/Data/Error.elm
+++ b/web/src/Data/Error.elm
@@ -1,0 +1,13 @@
+module Data.Error exposing (Error, decode)
+
+import Json.Decode
+
+
+type alias Error =
+    { message : String }
+
+
+decode : Json.Decode.Decoder Error
+decode =
+    Json.Decode.map Error
+        (Json.Decode.field "message" Json.Decode.string)

--- a/web/src/Pages/Auth.elm
+++ b/web/src/Pages/Auth.elm
@@ -8,7 +8,6 @@ import Effect exposing (Effect)
 import Html exposing (Html)
 import Html.Attributes as Attr
 import Html.Events
-import Http
 import Layouts
 import Page exposing (Page)
 import Route exposing (Route)
@@ -38,7 +37,7 @@ type alias Model =
     , passwordAgain : String
     , isSubmittingForm : Bool
     , formVariant : Variant
-    , error : Maybe Http.Error
+    , error : Maybe Api.Error
     }
 
 
@@ -71,8 +70,8 @@ type Msg
     = UserUpdatedInput Field String
     | UserChangedFormVariant Variant
     | UserClickedSubmit
-    | ApiSignInResponded (Result Http.Error Credentials)
-    | ApiSignUpResponded (Result Http.Error ())
+    | ApiSignInResponded (Result Api.Error Credentials)
+    | ApiSignUpResponded (Result Api.Error ())
 
 
 type Field
@@ -198,13 +197,23 @@ viewForm model =
         )
 
 
-viewError : Maybe Http.Error -> Html Msg
+viewError : Maybe Api.Error -> Html Msg
 viewError maybeError =
     case maybeError of
         Just error ->
+            let
+                text : String
+                text =
+                    case error of
+                        Api.HttpError err ->
+                            err.message
+
+                        Api.JsonDecodeError err ->
+                            err.message
+            in
             Html.div [ Attr.class "box bad" ]
                 [ Html.strong [ Attr.class "block titlebar" ] [ Html.text "Error" ]
-                , Html.text (Api.errorToFriendlyMessage error)
+                , Html.text text
                 ]
 
         Nothing ->

--- a/web/src/Pages/Auth.elm
+++ b/web/src/Pages/Auth.elm
@@ -201,19 +201,9 @@ viewError : Maybe Api.Error -> Html Msg
 viewError maybeError =
     case maybeError of
         Just error ->
-            let
-                text : String
-                text =
-                    case error of
-                        Api.HttpError err ->
-                            err.message
-
-                        Api.JsonDecodeError err ->
-                            err.message
-            in
             Html.div [ Attr.class "box bad" ]
                 [ Html.strong [ Attr.class "block titlebar" ] [ Html.text "Error" ]
-                , Html.text text
+                , Html.text (Api.getErrorMessage error)
                 ]
 
         Nothing ->

--- a/web/src/Pages/Auth.elm
+++ b/web/src/Pages/Auth.elm
@@ -203,7 +203,7 @@ viewError maybeError =
         Just error ->
             Html.div [ Attr.class "box bad" ]
                 [ Html.strong [ Attr.class "block titlebar" ] [ Html.text "Error" ]
-                , Html.text (Api.getErrorMessage error)
+                , Html.text (Api.errorMessage error)
                 ]
 
         Nothing ->

--- a/web/src/Pages/Auth.elm
+++ b/web/src/Pages/Auth.elm
@@ -239,9 +239,7 @@ viewForgotPassword : Html Msg
 viewForgotPassword =
     Html.div []
         [ Html.a
-            [ Attr.href "/forgot-password"
-            , Attr.class "gray"
-            ]
+            [ Attr.href "/forgot-password" ]
             [ Html.text "Forgot password?" ]
         ]
 

--- a/web/src/Pages/Profile/Me.elm
+++ b/web/src/Pages/Profile/Me.elm
@@ -86,11 +86,8 @@ viewProfileContent shared userResponse =
         Api.Success user ->
             viewUserDetails shared user
 
-        Api.Failure (Api.HttpError err) ->
-            Html.text err.message
-
-        Api.Failure (Api.JsonDecodeError err) ->
-            Html.text err.message
+        Api.Failure err ->
+            Html.text (Api.getErrorMessage err)
 
 
 viewUserDetails : Shared.Model -> Me -> Html Msg

--- a/web/src/Pages/Profile/Me.elm
+++ b/web/src/Pages/Profile/Me.elm
@@ -35,7 +35,7 @@ type alias Model =
 init : Shared.Model -> () -> ( Model, Effect Msg )
 init _ () =
     ( { me = Api.Loading }
-   , Api.Me.get { onResponse = ApiMeResponded }
+    , Api.Me.get { onResponse = ApiMeResponded }
     )
 
 

--- a/web/src/Pages/Profile/Me.elm
+++ b/web/src/Pages/Profile/Me.elm
@@ -35,7 +35,7 @@ type alias Model =
 init : Shared.Model -> () -> ( Model, Effect Msg )
 init _ () =
     ( { me = Api.Loading }
-    , Api.Me.get { onResponse = ApiMeResponded }
+   , Api.Me.get { onResponse = ApiMeResponded }
     )
 
 
@@ -87,7 +87,7 @@ viewProfileContent shared userResponse =
             viewUserDetails shared user
 
         Api.Failure err ->
-            Html.text (Api.getErrorMessage err)
+            Html.text (Api.errorMessage err)
 
 
 viewUserDetails : Shared.Model -> Me -> Html Msg

--- a/web/src/Pages/Profile/Me.elm
+++ b/web/src/Pages/Profile/Me.elm
@@ -6,7 +6,6 @@ import Auth
 import Data.Me exposing (Me)
 import Effect exposing (Effect)
 import Html exposing (Html)
-import Http
 import Layouts
 import Page exposing (Page)
 import Route exposing (Route)
@@ -45,7 +44,7 @@ init _ () =
 
 
 type Msg
-    = ApiMeResponded (Result Http.Error Me)
+    = ApiMeResponded (Result Api.Error Me)
 
 
 update : Msg -> Model -> ( Model, Effect Msg )
@@ -87,8 +86,11 @@ viewProfileContent shared userResponse =
         Api.Success user ->
             viewUserDetails shared user
 
-        Api.Failure err ->
-            Html.text (Api.errorToFriendlyMessage err)
+        Api.Failure (Api.HttpError err) ->
+            Html.text err.message
+
+        Api.Failure (Api.JsonDecodeError err) ->
+            Html.text err.message
 
 
 viewUserDetails : Shared.Model -> Me -> Html Msg

--- a/web/src/Shared/Msg.elm
+++ b/web/src/Shared/Msg.elm
@@ -1,7 +1,7 @@
 module Shared.Msg exposing (Msg(..))
 
+import Api
 import Data.Credentials exposing (Credentials)
-import Http
 import Time
 
 
@@ -13,4 +13,4 @@ type Msg
       -- Session
     | CheckTokenExpiration Time.Posix
     | TriggerTokenRefresh
-    | ApiRefreshTokensResponded (Result Http.Error Credentials)
+    | ApiRefreshTokensResponded (Result Api.Error Credentials)

--- a/web/tests/UnitTests/Data/Credentiala.elm
+++ b/web/tests/UnitTests/Data/Credentiala.elm
@@ -9,7 +9,7 @@ import Test exposing (Test, describe, test)
 suite : Test
 suite =
     describe "Data.Credentials"
-        [ test "decode credentials" <|
+        [ test "decode" <|
             \_ ->
                 """
                 {

--- a/web/tests/UnitTests/Data/Error.elm
+++ b/web/tests/UnitTests/Data/Error.elm
@@ -1,0 +1,21 @@
+module UnitTests.Data.Error exposing (suite)
+
+import Data.Error
+import Expect
+import Json.Decode as Json
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "Data.Error"
+        [ test "decode" <|
+            \_ ->
+                """
+                {
+                    "message": "some kind of an error"
+                }
+                """
+                    |> Json.decodeString Data.Error.decode
+                    |> Expect.equal (Ok { message = "some kind of an error" })
+        ]

--- a/web/tests/UnitTests/Data/Me.elm
+++ b/web/tests/UnitTests/Data/Me.elm
@@ -9,7 +9,7 @@ import Test exposing (Test, describe, test)
 suite : Test
 suite =
     describe "Data.Me"
-        [ test "decode credentials" <|
+        [ test "decode" <|
             \_ ->
                 """
                 {


### PR DESCRIPTION
Added new `Api.Error` to handle json parsing and http error.
Since there's no way to get a body from `Http.Error` if response is error, we need to have this custom error type.
