### PR TITLE
fix: get note metadata

### DIFF
--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -268,7 +268,7 @@ func (e *AppTestSuite) TestNoteV1_GetMetadata_withPassword() {
 
 	// get metadata
 	metaResp := e.httpRequest(http.MethodGet, "/api/v1/note/"+bodyCreated.Slug+"/meta", []byte{})
-	e.Equal(metaResp.Code, http.StatusOK)
+	e.Equal(http.StatusOK, metaResp.Code)
 
 	var metadata apiv1NoteMetadataResponse
 	e.readBodyAndUnjsonify(metaResp.Body, &metadata)
@@ -279,5 +279,26 @@ func (e *AppTestSuite) TestNoteV1_GetMetadata_withPassword() {
 
 func (e *AppTestSuite) TestNoteV1_GetMetadata_notFound() {
 	metaResp := e.httpRequest(http.MethodGet, "/api/v1/note/"+e.uuid()+"/meta", []byte{})
+	e.Equal(http.StatusNotFound, metaResp.Code)
+}
+
+func (e *AppTestSuite) TestNoteV1_GetMetadata_readNote() {
+	// create note
+	createdResp := e.httpRequest(
+		http.MethodPost,
+		"/api/v1/note",
+		e.jsonify(apiv1NoteCreateRequest{Content: "content"}), //nolint:exhaustruct
+	)
+	e.Equal(http.StatusCreated, createdResp.Code)
+
+	var bodyCreated apiv1NoteCreateResponse
+	e.readBodyAndUnjsonify(createdResp.Body, &bodyCreated)
+
+	// read note
+	readResp := e.httpRequest(http.MethodGet, "/api/v1/note/"+bodyCreated.Slug, nil)
+	e.Equal(http.StatusOK, readResp.Code)
+
+	// get metadata
+	metaResp := e.httpRequest(http.MethodGet, "/api/v1/note/"+e.uuid()+"/meta", nil)
 	e.Equal(http.StatusNotFound, metaResp.Code)
 }

--- a/internal/service/notesrv/notesrv.go
+++ b/internal/service/notesrv/notesrv.go
@@ -225,7 +225,7 @@ func (n *NoteSrv) getNote(ctx context.Context, inp GetNoteBySlugInput) (models.N
 		return models.Note{}, err
 	}
 
-	if !note.IsRead() {
+	if note.IsRead() {
 		if err = n.cache.SetNote(ctx, inp.Slug, note); err != nil {
 			slog.ErrorContext(ctx, "notecache", "err", err)
 		}

--- a/internal/store/psql/noterepo/noterepo.go
+++ b/internal/store/psql/noterepo/noterepo.go
@@ -22,7 +22,7 @@ type NoteStorer interface {
 	GetBySlug(ctx context.Context, slug dtos.NoteSlug) (models.Note, error)
 
 	// GetMetadataBySlug gets note's metadata by its slug.
-	// Returns [models.ErrNoteNotFound] if note is not found.
+	// Returns [models.ErrNoteNotFound] if note is not found OR read.
 	GetMetadataBySlug(ctx context.Context, slug dtos.NoteSlug) (dtos.NoteMetadata, error)
 
 	// GetAllByAuthorID returns all notes with specified author.
@@ -123,19 +123,19 @@ func (s *NoteRepo) GetMetadataBySlug(
 	slug dtos.NoteSlug,
 ) (dtos.NoteMetadata, error) {
 	query := `--sql
-	select n.created_at, (n.password is not null and n.password <> '') has_password, n.read_at is not null
+	select n.created_at, (n.password is not null and n.password <> '') has_password, n.read_at
 	from notes n
 	where slug = $1
 	`
 
-	var isRead bool
+	var readAt time.Time
 	var metadata dtos.NoteMetadata
-	err := s.db.QueryRow(ctx, query, slug).Scan(&metadata.CreatedAt, &metadata.HasPassword)
+	err := s.db.QueryRow(ctx, query, slug).Scan(&metadata.CreatedAt, &metadata.HasPassword, &readAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return dtos.NoteMetadata{}, models.ErrNoteNotFound
 	}
 
-	if isRead {
+	if !readAt.IsZero() {
 		return dtos.NoteMetadata{}, models.ErrNoteNotFound
 	}
 

--- a/internal/store/psql/noterepo/noterepo.go
+++ b/internal/store/psql/noterepo/noterepo.go
@@ -123,14 +123,19 @@ func (s *NoteRepo) GetMetadataBySlug(
 	slug dtos.NoteSlug,
 ) (dtos.NoteMetadata, error) {
 	query := `--sql
-	select n.created_at, (n.password is not null and n.password <> '') has_password
+	select n.created_at, (n.password is not null and n.password <> '') has_password, n.read_at is not null
 	from notes n
 	where slug = $1
 	`
 
+	var isRead bool
 	var metadata dtos.NoteMetadata
 	err := s.db.QueryRow(ctx, query, slug).Scan(&metadata.CreatedAt, &metadata.HasPassword)
 	if errors.Is(err, pgx.ErrNoRows) {
+		return dtos.NoteMetadata{}, models.ErrNoteNotFound
+	}
+
+	if isRead {
 		return dtos.NoteMetadata{}, models.ErrNoteNotFound
 	}
 


### PR DESCRIPTION
- /api/v1/note/:slug/meta should return 404 if the note is not found, OR is read.
- fixes cache, stores only read notes to the cache, so there won't be note's content in the cache.