### PR TITLE
fix(api): get note with password

### DIFF
--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -139,10 +139,6 @@ func (e *AppTestSuite) TestNoteV1_Get() {
 	e.Equal(dbNote.ReadAt.IsZero(), false)
 }
 
-type apiv1NoteGetRequest struct {
-	Password string `json:"password"`
-}
-
 func (e *AppTestSuite) TestNoteV1_GetWithPassword() {
 	content := e.uuid()
 	passwd := e.uuid()
@@ -161,10 +157,8 @@ func (e *AppTestSuite) TestNoteV1_GetWithPassword() {
 
 	httpResp = e.httpRequest(
 		http.MethodGet,
-		"/api/v1/note/"+bodyCreated.Slug,
-		e.jsonify(apiv1NoteGetRequest{
-			Password: passwd,
-		}),
+		"/api/v1/note/"+bodyCreated.Slug+"?password="+passwd,
+		nil,
 	)
 	e.Equal(httpResp.Code, http.StatusOK)
 
@@ -215,10 +209,8 @@ func (e *AppTestSuite) TestNoteV1_GetWithPassword_wrong() {
 
 	httpResp = e.httpRequest(
 		http.MethodGet,
-		"/api/v1/note/"+bodyCreated.Slug,
-		e.jsonify(apiv1NoteGetRequest{
-			Password: e.uuid(),
-		}),
+		"/api/v1/note/"+bodyCreated.Slug+"?password="+e.uuid(),
+		nil,
 	)
 	e.Equal(httpResp.Code, http.StatusNotFound)
 }

--- a/internal/service/notesrv/input.go
+++ b/internal/service/notesrv/input.go
@@ -8,7 +8,7 @@ type GetNoteBySlugInput struct {
 	Slug dtos.NoteSlug
 
 	// Password is a note's password.
-	// Optional, needed only if note has one.
+	// Leave it `""` if note has no password.
 	Password string
 }
 

--- a/internal/transport/http/apiv1/note.go
+++ b/internal/transport/http/apiv1/note.go
@@ -1,8 +1,6 @@
 package apiv1
 
 import (
-	"errors"
-	"io"
 	"net/http"
 	"time"
 
@@ -49,10 +47,6 @@ func (a *APIV1) createNoteHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, createNoteResponse{slug})
 }
 
-type getNoteBySlugRequest struct {
-	Password string `json:"password"`
-}
-
 type getNoteBySlugResponse struct {
 	Content              string    `json:"content"`
 	ReadAt               time.Time `json:"read_at,omitzero"`
@@ -62,17 +56,11 @@ type getNoteBySlugResponse struct {
 }
 
 func (a *APIV1) getNoteBySlugHandler(c *gin.Context) {
-	var req getNoteBySlugRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		newError(c, http.StatusBadRequest, "invalid request")
-		return
-	}
-
 	note, err := a.notesrv.GetBySlugAndRemoveIfNeeded(
 		c.Request.Context(),
 		notesrv.GetNoteBySlugInput{
 			Slug:     c.Param("slug"),
-			Password: req.Password,
+			Password: c.Query("password"),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Since browsers don't allow GET/HEAD requests with a body, we need to put this data into the url itself.

The more secure way of doing this would be making the POST /note/:slug/view route, but i'll leave it for the future.