### PR TITLE
chore(elm-reivew): allow missing type annotation in let statements

### DIFF
--- a/web/review/src/ReviewConfig.elm
+++ b/web/review/src/ReviewConfig.elm
@@ -7,7 +7,6 @@ import NoDebug.TodoOrToString
 import NoExposingEverything
 import NoImportingEverything
 import NoMissingTypeAnnotation
-import NoMissingTypeAnnotationInLetIn
 import NoMissingTypeExpose
 import NoPrematureLetComputation
 import NoSimpleLetBody
@@ -32,7 +31,6 @@ config =
     , NoExposingEverything.rule
     , NoImportingEverything.rule []
     , NoMissingTypeAnnotation.rule
-    , NoMissingTypeAnnotationInLetIn.rule
     , NoMissingTypeExpose.rule
     , NoSimpleLetBody.rule
     , NoPrematureLetComputation.rule

--- a/web/src/Pages/Auth.elm
+++ b/web/src/Pages/Auth.elm
@@ -210,11 +210,9 @@ viewBanner model =
 viewBannerSuccess : Maybe Posix -> Maybe Posix -> Html Msg
 viewBannerSuccess now lastClicked =
     let
-        buttonClassesBase : String
         buttonClassesBase =
             "w-full px-4 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2 transition-colors mt-3"
 
-        buttonClasses : Bool -> String
         buttonClasses active =
             if active then
                 buttonClassesBase ++ " border border-gray-300 text-gray-700 hover:bg-gray-50"
@@ -227,7 +225,6 @@ viewBannerSuccess now lastClicked =
             case ( now, lastClicked ) of
                 ( Just now_, Just last ) ->
                     let
-                        remainingMs : Int
                         remainingMs =
                             30 * 1000 - (Time.posixToMillis now_ - Time.posixToMillis last)
                     in
@@ -287,7 +284,6 @@ viewHeader variant =
 viewChangeVariant : Variant -> Html Msg
 viewChangeVariant variant =
     let
-        base : String
         base =
             "flex-1 px-4 py-2 rounded-md font-medium transition-colors"
 

--- a/web/src/Pages/Home_.elm
+++ b/web/src/Pages/Home_.elm
@@ -105,7 +105,6 @@ update shared msg model =
 
         UserClickedSubmit ->
             let
-                expiresAt : Posix
                 expiresAt =
                     case ( model.now, model.expirationTime ) of
                         ( Just now, Just expirationTime ) ->
@@ -442,7 +441,6 @@ viewNoteCreated userClickedCopyLink appUrl slug =
 viewCopyLinkButton : Bool -> Html Msg
 viewCopyLinkButton isClicked =
     let
-        base : String
         base =
             "px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2 transition-colors"
     in

--- a/web/src/Pages/Secret/Slug_.elm
+++ b/web/src/Pages/Secret/Slug_.elm
@@ -273,14 +273,11 @@ viewOpenNote :
     -> Html Msg
 viewOpenNote opts =
     let
-        isDisabled : Bool
         isDisabled =
             opts.hasPassword && Maybe.withDefault "" opts.password == ""
 
-        buttonData : { text : String, class : String }
         buttonData =
             let
-                base : String
                 base =
                     "px-6 py-3 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2 transition-colors"
             in


### PR DESCRIPTION
Most of the time those type annotation are just annoying, so now they optional
