### PR TITLE
refactor: don't pass note password in url

### DIFF
--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -139,6 +139,10 @@ func (e *AppTestSuite) TestNoteV1_Get() {
 	e.Equal(dbNote.ReadAt.IsZero(), false)
 }
 
+type apiv1NoteGetWithPasswordRequest struct {
+	Password string `json:"password"`
+}
+
 func (e *AppTestSuite) TestNoteV1_GetWithPassword() {
 	content := e.uuid()
 	passwd := e.uuid()
@@ -156,9 +160,11 @@ func (e *AppTestSuite) TestNoteV1_GetWithPassword() {
 	e.readBodyAndUnjsonify(httpResp.Body, &bodyCreated)
 
 	httpResp = e.httpRequest(
-		http.MethodGet,
-		"/api/v1/note/"+bodyCreated.Slug+"?password="+passwd,
-		nil,
+		http.MethodPost,
+		"/api/v1/note/"+bodyCreated.Slug+"/view",
+		e.jsonify(apiv1NoteGetWithPasswordRequest{
+			Password: passwd,
+		}),
 	)
 	e.Equal(httpResp.Code, http.StatusOK)
 
@@ -208,9 +214,11 @@ func (e *AppTestSuite) TestNoteV1_GetWithPassword_wrong() {
 	e.readBodyAndUnjsonify(httpResp.Body, &bodyCreated)
 
 	httpResp = e.httpRequest(
-		http.MethodGet,
-		"/api/v1/note/"+bodyCreated.Slug+"?password="+e.uuid(),
-		nil,
+		http.MethodPost,
+		"/api/v1/note/"+bodyCreated.Slug+"/view",
+		e.jsonify(apiv1NoteGetWithPasswordRequest{
+			Password: e.uuid(),
+		}),
 	)
 	e.Equal(httpResp.Code, http.StatusNotFound)
 }

--- a/internal/service/notesrv/input.go
+++ b/internal/service/notesrv/input.go
@@ -2,6 +2,8 @@ package notesrv
 
 import "github.com/olexsmir/onasty/internal/dtos"
 
+const EmptyPassword = ""
+
 // GetNoteBySlugInput used as input for [GetBySlugAndRemoveIfNeeded]
 type GetNoteBySlugInput struct {
 	// Slug is a note's slug :) *Required*
@@ -13,5 +15,5 @@ type GetNoteBySlugInput struct {
 }
 
 func (i GetNoteBySlugInput) HasPassword() bool {
-	return i.Password != ""
+	return i.Password != EmptyPassword
 }

--- a/internal/transport/http/apiv1/apiv1.go
+++ b/internal/transport/http/apiv1/apiv1.go
@@ -59,8 +59,8 @@ func (a *APIV1) Routes(r *gin.RouterGroup) {
 	note := r.Group("/note")
 	{
 		note.GET("/:slug", a.getNoteBySlugHandler)
-		note.GET("/:slug/meta", a.getNoteMetadataByIDHandler)
 		note.POST("/:slug/view", a.getNoteBySlugAndPasswordHandler)
+		note.GET("/:slug/meta", a.getNoteMetadataByIDHandler)
 
 		possiblyAuthorized := note.Group("", a.couldBeAuthorizedMiddleware)
 		{

--- a/internal/transport/http/apiv1/apiv1.go
+++ b/internal/transport/http/apiv1/apiv1.go
@@ -60,6 +60,7 @@ func (a *APIV1) Routes(r *gin.RouterGroup) {
 	{
 		note.GET("/:slug", a.getNoteBySlugHandler)
 		note.GET("/:slug/meta", a.getNoteMetadataByIDHandler)
+		note.POST("/:slug/view", a.getNoteBySlugAndPasswordHandler)
 
 		possiblyAuthorized := note.Group("", a.couldBeAuthorizedMiddleware)
 		{

--- a/internal/transport/http/apiv1/note.go
+++ b/internal/transport/http/apiv1/note.go
@@ -60,7 +60,44 @@ func (a *APIV1) getNoteBySlugHandler(c *gin.Context) {
 		c.Request.Context(),
 		notesrv.GetNoteBySlugInput{
 			Slug:     c.Param("slug"),
-			Password: c.Query("password"),
+			Password: "",
+		},
+	)
+	if err != nil {
+		errorResponse(c, err)
+		return
+	}
+
+	status := http.StatusOK
+	if !note.ReadAt.IsZero() {
+		status = http.StatusNotFound
+	}
+
+	c.JSON(status, getNoteBySlugResponse{
+		Content:              note.Content,
+		ReadAt:               note.ReadAt,
+		CreatedAt:            note.CreatedAt,
+		ExpiresAt:            note.ExpiresAt,
+		BurnBeforeExpiration: note.BurnBeforeExpiration,
+	})
+}
+
+type getNoteBuySlugAndPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+func (a *APIV1) getNoteBySlugAndPasswordHandler(c *gin.Context) {
+	var req getNoteBuySlugAndPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		newError(c, http.StatusBadRequest, "invalid request")
+		return
+	}
+
+	note, err := a.notesrv.GetBySlugAndRemoveIfNeeded(
+		c.Request.Context(),
+		notesrv.GetNoteBySlugInput{
+			Slug:     c.Param("slug"),
+			Password: req.Password,
 		},
 	)
 	if err != nil {

--- a/internal/transport/http/apiv1/note.go
+++ b/internal/transport/http/apiv1/note.go
@@ -60,7 +60,7 @@ func (a *APIV1) getNoteBySlugHandler(c *gin.Context) {
 		c.Request.Context(),
 		notesrv.GetNoteBySlugInput{
 			Slug:     c.Param("slug"),
-			Password: "",
+			Password: notesrv.EmptyPassword,
 		},
 	)
 	if err != nil {

--- a/web/src/Api/Note.elm
+++ b/web/src/Api/Note.elm
@@ -7,7 +7,6 @@ import Http
 import Iso8601
 import Json.Encode as E
 import Time exposing (Posix)
-import Url
 
 
 create :

--- a/web/src/Api/Note.elm
+++ b/web/src/Api/Note.elm
@@ -59,22 +59,24 @@ get :
     }
     -> Effect msg
 get options =
-    Effect.sendApiRequest
-        { endpoint =
-            "/api/v1/note/"
-                ++ options.slug
-                ++ (case options.password of
-                        Just p ->
-                            "?password=" ++ Url.percentEncode p
+    case options.password of
+        Just passwd ->
+            Effect.sendApiRequest
+                { endpoint = "/api/v1/note/" ++ options.slug ++ "/view"
+                , method = "POST"
+                , body = E.object [ ( "password", E.string passwd ) ] |> Http.jsonBody
+                , onResponse = options.onResponse
+                , decoder = Note.decode
+                }
 
-                        Nothing ->
-                            ""
-                   )
-        , method = "GET"
-        , body = Http.emptyBody
-        , onResponse = options.onResponse
-        , decoder = Note.decode
-        }
+        Nothing ->
+            Effect.sendApiRequest
+                { endpoint = "/api/v1/note/" ++ options.slug
+                , method = "GET"
+                , body = Http.emptyBody
+                , onResponse = options.onResponse
+                , decoder = Note.decode
+                }
 
 
 getMetadata :


### PR DESCRIPTION
That's follow up on #151, this pr adds `/api/v1/note/:slug/view` route, so the password is passed in the request body, and not the url.
