### PR TITLE
fix: return "invalid slug" error to user

### DIFF
--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/olexsmir/onasty/internal/models"
 )
 
 type (
@@ -74,6 +75,36 @@ func (e *AppTestSuite) TestNoteV1_Create() {
 			},
 			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
 				e.Equal(http.StatusBadRequest, r.Code)
+			},
+		},
+		{
+			name: "invalid slug, 'read'",
+			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
+				Slug:    "read",
+				Content: e.uuid(),
+			},
+			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
+				e.Equal(r.Code, http.StatusBadRequest)
+
+				var body errorResponse
+				e.readBodyAndUnjsonify(r.Body, &body)
+
+				e.Equal(models.ErrNoteSlugIsAlreadyInUse.Error(), body.Message)
+			},
+		},
+		{
+			name: "invalid slug, 'unread'",
+			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
+				Slug:    "unread",
+				Content: e.uuid(),
+			},
+			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
+				e.Equal(r.Code, http.StatusBadRequest)
+
+				var body errorResponse
+				e.readBodyAndUnjsonify(r.Body, &body)
+
+				e.Equal(models.ErrNoteSlugIsAlreadyInUse.Error(), body.Message)
 			},
 		},
 		{

--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -67,13 +67,40 @@ func (e *AppTestSuite) TestNoteV1_Create() {
 			},
 		},
 		{
+			name: "invalid slug, with space",
+			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
+				Slug:    e.uuid() + "fuker fuker",
+				Content: e.uuid(),
+			},
+			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
+				e.Equal(http.StatusBadRequest, r.Code)
+			},
+		},
+		{
+			name: "slug provided but empty",
+			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
+				Slug:    "",
+				Content: e.uuid(),
+			},
+			assert: func(r *httptest.ResponseRecorder, inp apiv1NoteCreateRequest) {
+				e.Equal(r.Code, http.StatusCreated)
+
+				var body apiv1NoteCreateResponse
+				e.readBodyAndUnjsonify(r.Body, &body)
+
+				dbNote := e.getNoteBySlug(body.Slug)
+				e.NotEmpty(dbNote)
+				e.Equal(inp.Content, dbNote.Content)
+			},
+		},
+		{
 			name: "set password",
 			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
 				Content:  e.uuid(),
 				Password: e.uuid(),
 			},
 			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
-				e.Equal(r.Code, http.StatusCreated)
+				e.Equal(http.StatusCreated, r.Code)
 			},
 		},
 		{

--- a/e2e/apiv1_notes_test.go
+++ b/e2e/apiv1_notes_test.go
@@ -78,6 +78,16 @@ func (e *AppTestSuite) TestNoteV1_Create() {
 			},
 		},
 		{
+			name: "invalid slug, with slash",
+			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
+				Slug:    e.uuid() + "fuker/fuker",
+				Content: e.uuid(),
+			},
+			assert: func(r *httptest.ResponseRecorder, _ apiv1NoteCreateRequest) {
+				e.Equal(http.StatusBadRequest, r.Code)
+			},
+		},
+		{
 			name: "invalid slug, 'read'",
 			inp: apiv1NoteCreateRequest{ //nolint:exhaustruct
 				Slug:    "read",

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -32,7 +32,7 @@ func (n Note) Validate() error {
 		return ErrNoteContentIsEmpty
 	}
 
-	if n.Slug == "" || strings.Contains(n.Slug, " ") {
+	if strings.Contains(n.Slug, " ") {
 		return ErrNoteSlugIsInvalid
 	}
 

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -38,7 +38,7 @@ func (n Note) Validate() error {
 		return ErrNoteContentIsEmpty
 	}
 
-	if strings.Contains(n.Slug, " ") {
+	if strings.Contains(n.Slug, " ") || strings.Contains(n.Slug, "/") {
 		return ErrNoteSlugIsInvalid
 	}
 

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -8,6 +8,12 @@ import (
 	"github.com/gofrs/uuid/v5"
 )
 
+// read and unread are not allowed because those slugs might and will be interpreted as api routes
+var notAllowedSlugs = map[string]struct{}{
+	"read":   {},
+	"unread": {},
+}
+
 var (
 	ErrNoteContentIsEmpty     = errors.New("note: content is empty")
 	ErrNoteSlugIsAlreadyInUse = errors.New("note: slug is already in use")
@@ -38,6 +44,10 @@ func (n Note) Validate() error {
 
 	if n.IsExpired() {
 		return ErrNoteExpired
+	}
+
+	if _, exists := notAllowedSlugs[n.Slug]; exists {
+		return ErrNoteSlugIsAlreadyInUse
 	}
 
 	return nil

--- a/internal/models/note.go
+++ b/internal/models/note.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"errors"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -33,12 +33,14 @@ type Note struct {
 	ExpiresAt            time.Time
 }
 
+var slugPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
 func (n Note) Validate() error {
 	if n.Content == "" {
 		return ErrNoteContentIsEmpty
 	}
 
-	if strings.Contains(n.Slug, " ") || strings.Contains(n.Slug, "/") {
+	if !slugPattern.MatchString(n.Slug) {
 		return ErrNoteSlugIsInvalid
 	}
 

--- a/internal/models/note_test.go
+++ b/internal/models/note_test.go
@@ -44,10 +44,6 @@ func TestNote_Validate(t *testing.T) {
 		assert.EqualError(t, n.Validate(), ErrNoteExpired.Error())
 	})
 	t.Run("should fail if slug is empty", func(t *testing.T) {
-		n := Note{Content: "the content", Slug: ""}
-		assert.EqualError(t, n.Validate(), ErrNoteSlugIsInvalid.Error())
-	})
-	t.Run("should fail if slug is empty", func(t *testing.T) {
 		n := Note{Content: "the content", Slug: " "}
 		assert.EqualError(t, n.Validate(), ErrNoteSlugIsInvalid.Error())
 	})

--- a/internal/models/note_test.go
+++ b/internal/models/note_test.go
@@ -47,6 +47,10 @@ func TestNote_Validate(t *testing.T) {
 		n := Note{Content: "the content", Slug: " "}
 		assert.EqualError(t, n.Validate(), ErrNoteSlugIsInvalid.Error())
 	})
+	t.Run("should fail if slug has '/'", func(t *testing.T) {
+		n := Note{Content: "the content", Slug: "asdf/asdf"}
+		assert.EqualError(t, n.Validate(), ErrNoteSlugIsInvalid.Error())
+	})
 	t.Run("should fail if slug one of not allowed slugs", func(t *testing.T) {
 		for notAllowedSlug := range notAllowedSlugs {
 			n := Note{Content: "the content", Slug: notAllowedSlug}

--- a/internal/models/note_test.go
+++ b/internal/models/note_test.go
@@ -47,6 +47,12 @@ func TestNote_Validate(t *testing.T) {
 		n := Note{Content: "the content", Slug: " "}
 		assert.EqualError(t, n.Validate(), ErrNoteSlugIsInvalid.Error())
 	})
+	t.Run("should fail if slug one of not allowed slugs", func(t *testing.T) {
+		for notAllowedSlug := range notAllowedSlugs {
+			n := Note{Content: "the content", Slug: notAllowedSlug}
+			assert.EqualError(t, n.Validate(), ErrNoteSlugIsAlreadyInUse.Error())
+		}
+	})
 }
 
 //nolint:exhaustruct

--- a/internal/transport/http/apiv1/apiv1.go
+++ b/internal/transport/http/apiv1/apiv1.go
@@ -75,11 +75,8 @@ func (a *APIV1) Routes(r *gin.RouterGroup) {
 		authorized := note.Group("", a.authorizedMiddleware)
 		{
 			authorized.GET("", a.getNotesHandler)
-
-			// FIXME: those links make slugs `read` and `unread` unavailable
 			authorized.GET("/read", a.getReadNotesHandler)
 			authorized.GET("/unread", a.getUnReadNotesHandler)
-
 			authorized.PATCH(":slug/expires", a.updateNoteHandler)
 			authorized.PATCH(":slug/password", a.setNotePasswordHandler)
 			authorized.DELETE(":slug", a.deleteNoteHandler)

--- a/internal/transport/http/apiv1/response.go
+++ b/internal/transport/http/apiv1/response.go
@@ -32,7 +32,8 @@ func errorResponse(c *gin.Context, err error) {
 		// notes
 		errors.Is(err, notesrv.ErrNotePasswordNotProvided) ||
 		errors.Is(err, models.ErrNoteContentIsEmpty) ||
-		errors.Is(err, models.ErrNoteSlugIsAlreadyInUse) {
+		errors.Is(err, models.ErrNoteSlugIsAlreadyInUse) ||
+		errors.Is(err, models.ErrNoteSlugIsInvalid) {
 		newError(c, http.StatusBadRequest, err.Error())
 		return
 	}


### PR DESCRIPTION
#164 introduced slug validation, but did not return the error to user. This commit returns the error to user instead of returning "internal error".

#188 didn't validate for `unread` and `read` slugs, so this PR did.