### PR TITLE
fix(api): change password exposes internal error

### DIFF
--- a/e2e/apiv1_auth_test.go
+++ b/e2e/apiv1_auth_test.go
@@ -347,16 +347,15 @@ type apiv1AuthChangePasswordRequest struct {
 }
 
 func (e *AppTestSuite) TestAuthV1_ChangePassword() {
-	password := e.uuid()
-	newPassword := e.uuid()
+	oldPassword, newPassword := e.uuid(), e.uuid()
 	email := e.uuid() + "@test.com"
-	_, toks := e.createAndSingIn(email, password)
+	_, toks := e.createAndSingIn(email, oldPassword)
 
 	httpResp := e.httpRequest(
 		http.MethodPost,
 		"/api/v1/auth/change-password",
 		e.jsonify(apiv1AuthChangePasswordRequest{
-			CurrentPassword: password,
+			CurrentPassword: oldPassword,
 			NewPassword:     newPassword,
 		}),
 		toks.AccessToken,
@@ -385,6 +384,10 @@ func (e *AppTestSuite) TestAuthV1_ChangePassword_wrongPassword() {
 	)
 
 	e.Equal(http.StatusBadRequest, httpResp.Code)
+
+	var body errorResponse
+	e.readBodyAndUnjsonify(httpResp.Body, &body)
+	e.Equal(models.ErrUserWrongCredentials.Error(), body.Message)
 
 	userDB := e.getUserByEmail(email)
 

--- a/internal/service/usersrv/usersrv.go
+++ b/internal/service/usersrv/usersrv.go
@@ -264,7 +264,7 @@ func (u *UserSrv) ChangePassword(
 	}
 
 	if err = u.hasher.Compare(user.Password, inp.CurrentPassword); err != nil {
-		return errors.Join(err, models.ErrUserInvalidPassword)
+		return models.ErrUserWrongCredentials
 	}
 
 	newPass, err := u.hasher.Hash(inp.NewPassword)


### PR DESCRIPTION
If current user's password and provided ones didn't match, api returned ErrUserInvalidPassword, now it's ErrUserWrongCredentials